### PR TITLE
Removing venv

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.9.1
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.9.0](https://img.shields.io/badge/version-0.9.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.9.1](https://img.shields.io/badge/version-0.9.1-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![Build Status](https://travis-ci.org/bnbalsamo/cookiecutter-pypackage.svg?branch=master)](https://travis-ci.org/bnbalsamo/cookiecutter-pypackage)
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,6 +18,5 @@
         "The Unlicense",
         "None/Other"
     ],
-    "venv_args": "",
     "create_docs_folder": "y"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,4 +1,3 @@
-from sys import version_info
 import os
 
 
@@ -23,31 +22,10 @@ def remove_docs_folder():
     remove_dir("docs")
 
 
-def make_venv():
-    if version_info < (3, 3):
-        # Can't build the venv, alert but don't fail.
-        print("Incompatible Python (<3.3). " +
-              "Virtual environment must be created manually\n")
-        return
-
-    from venv import main
-
-    cookiecutter_args = "{{cookiecutter.venv_args}}"
-    args = "{}".format(os.path.join(PROJECT_DIRECTORY, 'venv'))
-    if cookiecutter_args != "":
-        args = "{} {}".format(cookiecutter_args, args)
-    main(args.split())
-    print("Virtual environment successfully created. Activate " +
-          "it with: \n" +
-          "$ source venv/bin/activate \n" +
-          "from the project root\n")
-
-
 def main():
     if '{{ cookiecutter.create_docs_folder }}' != 'y':
         remove_docs_folder()
     print("Template successfully created.\n")
-    make_venv()
     print("Done")
 
 


### PR DESCRIPTION
There are a lot of tools for managing venvs, and when to apply these tools and which tools to use isn't necessarily the same between every package.

Thus, this patch removes the automated creation of a venv, which previously would have created a single venv in the project directory using the system python if the python version was > 3.3.