### PR TITLE
Introduce invoke

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,6 @@
 [bumpversion]
-current_version = 0.18.3
+current_version = 0.19.0
 commit = True
 tag = True
 
 [bumpversion:file:README.md]
-

--- a/README.md
+++ b/README.md
@@ -14,15 +14,14 @@ tl;dr: A CI enabled Python software project with plenty of bells and whistles.
 - [Coveralls](https://coveralls.io/) integration
 - [pyup](https://pyup.io/) integration
 - Testing via [tox](https://tox.readthedocs.io/en/latest/)
-- Tox environments to facilitate...
+- [Invoke](http://www.pyinvoke.org/) tasks to facilitate a variety of tasks, including...
     - Running autoformatters like black and isort
-    - Easily check `#TODO` comments
+    - Easily checking `#TODO` comments
     - Building documentation
-    - Pin depedencies to a `requirements.txt`
-    - Test release to pypi
-    - Release to pypi
-    - Build source distributions and wheels
-    - Build wheelhouses of your projects dependencies
+    - Pinning depedencies to a `requirements.txt`
+    - Releasing to pypi
+    - Building source distributions and wheels
+    - Building wheelhouses of your project's dependencies
 - A minimal README + relevant badges
 - (optional) [Sphinx](http://www.sphinx-doc.org) documentation
     - With a minimal autodocs setup
@@ -32,7 +31,6 @@ tl;dr: A CI enabled Python software project with plenty of bells and whistles.
     - [flake8](http://flake8.pycqa.org/en/latest/)
     - [pylint](https://www.pylint.org)
     - [coverage](https://coverage.readthedocs.io/en/latest/)
-    - [twine](https://pypi.python.org/pypi/twine)
     - [check-manifest](https://github.com/mgedmin/check-manifest)
     - [isort](https://github.com/timothycrosley/isort)
     - [bandit](https://github.com/PyCQA/bandit)
@@ -76,30 +74,49 @@ tl;dr: A CI enabled Python software project with plenty of bells and whistles.
 
 # Functionalities
 
-Any of the following can be run off the bat from the project root
+Any of the following can be run off the bat from the project root, via `invoke`/`inv`...
 
-* ```tox```:
-  * Run ```pytest```
-  * generate coverage metrics
-  * run ```flake8```
-  * run ```pydocstyle```
-  * run an ```isort``` check
-  * run a ```bandit``` check
-  * run a ```black``` check
-  * run a ```safety``` check
-  * run a ```checkmanifest``` check
-  * run a ```mypy``` check
-  * build the sphinx documentation
-* ```tox -e check_todos```: List all of the `# TODO` comment lines in the code
-* ```tox -e pindeps```: Generate a ```requirements.txt``` with pinned dependencies
-* ```tox -e run_isort```: Run isort on the codebase
-* ```tox -e run_black```: Run black on the codebase
-* ```tox -e build```: Build distribution packages
-* ```tox -e build_wheelhouse```: Build a wheelhouse of project dependencies
-* ```tox -e test_release```: Test releasing (with test.pypi.org)
-* ```tox -e release```: Release to pypi
-* ```bumpversion $PART```: Bump the version number of the project
-  * ```git push && git push --tags``` to upload/release to git
+```
+$ inv --list
+Available tasks:
+
+  pindeps                 Pin dependencies, creating or overwriting requirements.txt
+  release                 Perform a release to pypi.
+  build.coverage-report   Build an HTML coverage report.
+  build.dists             Build distribution artifacts.
+  build.docs              Build the documentation.
+  build.wheelhouse        Build a dependency wheelhouse.
+  check.todos             Check for `#TODO` comments in the code.
+  clean.all               Remove all clean-able artifacts.
+  clean.compiled          Remove compilation artifacts.
+  clean.coverage          Remove the .coverage cache.
+  clean.coverage-report   Remove the html coverage report.
+  clean.dists             Remove existing distributions.
+  clean.docs              Remove existing docs.
+  clean.mypy              Remove the .mypy_cache directory.
+  clean.tox               Remove the .tox cache directory.
+  clean.wheelhouse        Remove the wheelhouse.
+  run.autoformatters      Run all the autoformatters.
+  run.black               Run `black` to autoformat the source code.
+  run.isort               Run `isort` to autoformat the source code.
+  run.tests               Run the tests.
+```
+
+Additional information about commands can be obtained by using their `--help` flag, eg:
+
+```
+$ inv release --help
+Usage: inv[oke] [--core-opts] release [--options] [other tasks here ...]
+
+Docstring:
+  Perform a release to pypi.
+
+Options:
+  -b, --[no-]build
+  -c, --[no-]clean
+  -p, --prod
+  -s, --skip-tests
+```
 
 ## Uploading to pypi
 
@@ -108,11 +125,11 @@ Review your package before publishing it!
 [This](https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/) blog
 entry provides a good breakdown of uploading a package to pypi.
 
-This template provides several handy tox environments for packaging.
+The commands required to release are provided as an `invoke` task:
 
-* ```tox -e build```: Populates the dist/ folder with an sdist and bdist
-* ```tox -e test_release```: Perform a test release to https://test.pypi.org
-* ```tox -e release```: Perform a realease to PyPI.
+```
+$ inv release --prod  # Omit the --prod flag to publish to test.pypi
+```
 
 # Opinions
 
@@ -163,6 +180,16 @@ justification should be included in the git history.
 It uses a "src" layout
 
 I've [been](https://hynek.me/articles/testing-packaging/) [convinced](https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure).
+
+It uses [invoke](http://www.pyinvoke.org/) as a task runner
+
+The python ecosystem includes _a ton_ of useful tooling, but remembering the names, options,
+and flags for every individual command, as well as implementing consistent workflows involving
+all of them can be a chore.
+
+Invoke provides (in my opinion) a clean, extensible, understandable method for effectively
+utilizing all of these diverse tools, implementing repeatable workflows, and communicating
+usage information to contributors.
 
 # Credit Where It's Due
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.18.3](https://img.shields.io/badge/version-0.18.3-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.19.0](https://img.shields.io/badge/version-0.19.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![Build Status](https://travis-ci.org/bnbalsamo/cookiecutter-pypackage.svg?branch=master)](https://travis-ci.org/bnbalsamo/cookiecutter-pypackage)
 

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -16,14 +16,13 @@ See the full documentation at https://{{cookiecutter.github_repo_name }}.readthe
 # Development
 
 ## Installing Development Dependencies
-
 ```
 $ pip install -r requirements/requirements_dev.txt
 ```
 
 ## Running Tests
 ```
-$ tox
+$ inv run.tests
 ```
 Note: Tox will run tests against the version of the software installed via ```python setup.py install```.
 
@@ -31,12 +30,14 @@ To test against pinned dependencies add ```-r requirements.txt``` to the deps ar
 section.
 
 ## Running autoformatters
-
-- ```tox -e run_black,run_isort```
+```
+$ inv run.autoformatters
+```
 
 ## Pinning Dependencies
-- ```pip install -r requirements/requirements_dev.txt```
-- ```tox -e pindeps```
+```
+$ inv pindeps
+```
 
 # Author
 {{ cookiecutter.author }} <{{ cookiecutter.email }}>

--- a/{{ cookiecutter.project_name }}/requirements/requirements_dev.txt
+++ b/{{ cookiecutter.project_name }}/requirements/requirements_dev.txt
@@ -1,2 +1,10 @@
 -r requirements_tests.txt
-bumpversion
+-r requirements_docs.txt
+-r requirements_tests.txt
+bump2version
+invoke
+isort[pyproject]
+black
+wheel
+pep517
+twine

--- a/{{ cookiecutter.project_name }}/setup.py
+++ b/{{ cookiecutter.project_name }}/setup.py
@@ -22,10 +22,9 @@ EXTRAS_REQUIRE = {
     # 'webfrontend': {'flask'}
 }
 ENTRY_POINTS = {
-    # For CLI Scripts, if required
+    # For CLI scripts, plugins, etc if required
     # Ex:
     # 'console_scripts': ['mycli=mymodule:cli'],
-	#
 }
 
 

--- a/{{ cookiecutter.project_name }}/setup.py
+++ b/{{ cookiecutter.project_name }}/setup.py
@@ -27,7 +27,6 @@ ENTRY_POINTS = {
     # 'console_scripts': ['mycli=mymodule:cli'],
 	#
 }
-OPTIONS = {"bdist_wheel": {"universal": "1"}}
 
 
 def readme():
@@ -64,6 +63,5 @@ setup(
     url=URL,
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
-    python_requires=PYTHON_REQUIRES,
-    options=OPTIONS
+    python_requires=PYTHON_REQUIRES
 )

--- a/{{ cookiecutter.project_name }}/tasks.py
+++ b/{{ cookiecutter.project_name }}/tasks.py
@@ -302,6 +302,14 @@ def build_coverage_report(c, test=True):
     echo(f"Coverage report available at {str(Path('./htmlcov').resolve())}")
 
 
+@task(name="todos")
+def check_todos(c):
+    """
+    Check for `#TODO` comments in the code.
+    """
+    c.run("python -m pylint --disable=all --enable=W0511 src tests")
+
+
 @task()
 def release(c, prod=False, clean=True, build=True, skip_tests=False):
     """
@@ -362,7 +370,13 @@ clean_ns.add_task(clean_coverage_report)
 clean_ns.add_task(clean_all)
 
 
+# Define the "check" subcommand
+check_ns = Collection("check")
+check_ns.add_task(check_todos)
+
+
 # Add custom subcommands to root namespace
 ns.add_collection(run_ns)
 ns.add_collection(build_ns)
 ns.add_collection(clean_ns)
+ns.add_collection(check_ns)

--- a/{{ cookiecutter.project_name }}/tasks.py
+++ b/{{ cookiecutter.project_name }}/tasks.py
@@ -1,0 +1,225 @@
+"""
+Development tasks for {{ cookiecutter.project_name }}
+"""
+import os
+from pathlib import Path
+from shutil import rmtree
+
+from invoke import Collection, task
+
+
+# Change the CWD to the repo root.
+_LAST_DIR = None
+while not Path("./tasks.py").exists():
+    os.chdir("..")
+    _CURRENT_DIR = Path(".").resolve()
+    if _CURRENT_DIR == _LAST_DIR:
+        # We hit the FS root :(
+        raise FileNotFoundError("Could not find the repository root.")
+
+
+@task(name="pindeps")
+def _pindeps(c):
+    """
+    Pin dependencies, creating or overwriting requirements.txt
+    """
+    # Requires being run in a fresh virtualenv,
+    # so we leverage tox
+    c.run("tox -e pindeps --recreate")
+
+
+@task(name="black")
+def run_black(c):
+    """
+    Run `black` to autoformat the source code.
+    """
+    # The result of this command should satisfy the
+    # corresponding tox testenv check_black
+    c.run("python -m black ./src ./tests")
+
+
+@task(name="isort")
+def run_isort(c):
+    """
+    Run `isort` to autoformat the source code.
+    """
+    # The result of this command should satisfy the
+    # corresponding tox testenv check_isort
+    c.run("python -m isort -rc ./src ./tests")
+
+
+@task(name="autoformatters")
+def run_autoformatters(c):
+    """
+    Run all the autoformatters.
+    """
+    run_black(c)
+    run_isort(c)
+
+
+@task(name="tests")
+def run_tests(c, autoformat=True):
+    """
+    Run the tests.
+    """
+    if autoformat:
+        run_autoformatters(c)
+    c.run("tox")
+
+
+@task(name="docs")
+def build_docs(c, clean=True, buildername="html"):
+    """
+    Build the documentation.
+    """
+    if clean:
+        clean_docs(c)
+    c.run(f"sphinx-build docs docs_out --color -W -b{buildername}")
+
+
+@task(name="dists")
+def clean_dists(c):
+    """
+    Remove existing distributions.
+    """
+    dist_dir = Path("./dist").resolve()
+    if not dist_dir.exists():
+        return
+    if not dist_dir.is_dir():
+        raise NotADirectoryError(dist_dir)
+    print(f"Removing existing dist dir: {str(dist_dir)}")
+    for contents in dist_dir.iterdir():
+        contents.unlink()
+    dist_dir.rmdir()
+
+
+@task(name="docs")
+def clean_docs(c):
+    """
+    Remove existing docs.
+    """
+    docs_out_dir = Path("./docs_out").resolve()
+    if not docs_out_dir.exists():
+        return
+    if not docs_out_dir.is_dir():
+        raise NotADirectoryError(docs_out_dir)
+    print(f"Removing existing rendered docs dir: {str(docs_out_dir)}")
+    rmtree(docs_out_dir)
+
+
+@task(name="compiled")
+def clean_compiled(c):
+    """
+    Remove compilation artifacts.
+    """
+
+    def clean_dir(d):
+        for entry in d.iterdir():
+            if entry.name.endswith(".pyc"):
+                entry.unlink()
+            if entry.name == "__pycache__" or entry.name.endswith(".egg-info"):
+                rmtree(entry)
+                continue
+            if entry.is_dir():
+                clean_dir(entry)
+
+    dirs_to_clean = [
+        Path("./src").resolve(),
+        Path("./tests").resolve(),
+    ]
+    for d in dirs_to_clean:
+        print(f"Cleaning dir {str(d)}")
+        clean_dir(d)
+
+
+@task(name="all")
+def clean_all(c, dists=True, docs=True, compiled=True):
+    """
+    Remove all clean-able artifacts.
+    """
+    if dists:
+        clean_dists(c)
+    if docs:
+        clean_docs(c)
+    if compiled:
+        clean_compiled(c)
+
+
+@task(name="dists")
+def build_dists(c, clean=True):
+    """
+    Build distribution artifacts.
+    """
+    if clean:
+        clean_dists(c)
+    print("Building dists...")
+    c.run("python -m pep517.build -s -b .")
+    print(f"Dists now available in {Path('./dist').resolve()}")
+
+
+@task(name="wheelhouse")
+def build_wheelhouse(c, pindeps=True):
+    """
+    Build a dependency wheelhouse.
+    """
+    if pindeps:
+        _pindeps(c)
+    print("Creating wheelhouse...")
+    c.run("python -m pip wheel -w wheelhouse -r requirements.txt")
+    print(f"Wheelhouse now available in {Path('./wheelhouse').resolve()}")
+
+
+@task()
+def release(c, prod=False, clean=True, build=True, skip_tests=False):
+    """
+    Perform a release to pypi.
+    """
+    if not skip_tests:
+        run_tests(c)
+    if clean:
+        clean_dists(c)
+    if build:
+        build_dists(c)
+    cmd = "python -m twine upload"
+    if not prod:
+        cmd += " --repository-url https://test.pypi.org/legacy"
+    cmd += " ./dist/*"
+    c.run(cmd)
+
+
+# Make implicit root explicit
+ns = Collection()
+
+
+# Root commands
+ns.add_task(_pindeps)
+ns.add_task(release)
+
+
+# Define the "run" subcommand
+run_ns = Collection("run")
+run_ns.add_task(run_black)
+run_ns.add_task(run_isort)
+run_ns.add_task(run_tests)
+run_ns.add_task(run_autoformatters)
+
+
+# Define the "build" subcommand
+build_ns = Collection("build")
+build_ns.add_task(build_docs)
+build_ns.add_task(build_dists)
+build_ns.add_task(build_wheelhouse)
+
+
+# Define the "clean" subcommand
+clean_ns = Collection("clean")
+clean_ns.add_task(clean_dists)
+clean_ns.add_task(clean_docs)
+clean_ns.add_task(clean_compiled)
+clean_ns.add_task(clean_all)
+
+
+# Add custom subcommands to root namespace
+ns.add_collection(run_ns)
+ns.add_collection(build_ns)
+ns.add_collection(clean_ns)

--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -38,7 +38,7 @@ deps =
     isort[pyproject]
     pylint
 commands =
-    python -m pylint {posargs:src}
+    python -m pylint {posargs:src/{{ cookiecutter.slug_name }}}
 
 [testenv:check_todos]
 description = Check TODOs in the code
@@ -88,14 +88,6 @@ deps =
 commands =
     python -m isort -c {posargs:--diff -rc src tests}
 
-[testenv:run_isort]
-description = Sort import statements
-skip_install = true
-deps =
-    isort[pyproject]
-commands =
-    python -m isort {posargs:-rc src tests}
-
 [testenv:check_black]
 description = Check code formatting
 skip_install = true
@@ -104,21 +96,12 @@ deps =
 commands =
     python -m black --check {posargs:src tests}
 
-[testenv:run_black]
-description = Autoformat code
-skip_install = true
-deps =
-    black
-commands =
-    python -m black {posargs:src tests}
-
 [testenv:docs]
 description = Build sphinx documentation
 deps =
     -rrequirements/requirements_docs.txt
 commands =
-    sphinx-build -d "{toxworkdir}/docs_doctree" docs "docs_out" --color -W -bhtml {posargs}
-    python -c 'print("Documentation available under \{0\} in the project root".format("docs_out"))'
+    sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
 
 [testenv:checkmanifest]
 description = Check the MANIFEST.in
@@ -133,46 +116,3 @@ deps =
 recreate = true
 commands =
     python -c 'import datetime; from pip._internal.operations import freeze; x = freeze.freeze(skip=["{{ cookiecutter.slug_name }}", "pip", "setuptools", "wheel"]); f = open("requirements.txt", "w"); f.write("# Pinned on " + datetime.datetime.today().strftime("%Y-%m-%d") + "\n"); [f.write(p+"\n") for p in x]'
-
-[testenv:build]
-description = Build distribution packages
-skip_install = true
-deps =
-    wheel
-    pep517
-commands =
-    python -c 'import pathlib; (pathlib.Path("dist").exists() or pathlib.Path("build").exists()) and print("!!!!!!!!!!\ndist or build directories already exist in the project directory. You should probably delete them and rerun the build.\n!!!!!!!!!!")'
-    python -m pep517.build  -s -b .
-
-[testenv:test_release]
-passenv =
-    TWINE_USERNAME
-    TWINE_PASSWORD
-description = Upload the built package to the pypi test index.
-skip_install = true
-deps =
-    twine
-commands =
-    python -m pip install -U pip pep517 twine
-    python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-
-[testenv:release]
-passenv =
-    TWINE_USERNAME
-    TWINE_PASSWORD
-description = Upload the built package to pypi.
-skip_install = true
-deps =
-    twine
-commands =
-    python -m pip install -U pip pep517 twine
-    python -m twine upload dist/*
-
-[testenv:build_wheelhouse]
-description = Build a wheelhouse.
-skip_install = true
-deps =
-    pip
-commands =
-    python -c 'import pathlib; import sys; pathlib.Path("requirements.txt").exists() and print("Creating wheelhouse from requirements.txt...") is None or print("No requirements.txt exists in the project root!") is None and sys.exit(1)'
-    python -m pip wheel {posargs:-w wheelhouse -r requirements.txt}

--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -40,15 +40,6 @@ deps =
 commands =
     python -m pylint {posargs:src/{{ cookiecutter.slug_name }}}
 
-[testenv:check_todos]
-description = Check TODOs in the code
-skip_install = true
-deps =
-    isort[pyproject]
-    pylint
-commands =
-    python -m pylint {posargs:src -e W0511}
-
 [testenv:pydocstyle]
 description = Check docstrings
 skip_install = true


### PR DESCRIPTION
Rehouse functionality from tox testenvs into an invoke `tasks.py` where
appropriate.

Significantly fleshed out the available tasks

Replaces bumpversion with bump2version, which closes #22 