### PR TITLE
Use invoke instead of tox in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           set -xe
           python -VV
           python -m site
-          python -m pip install --upgrade pip setuptools wheel cookiecutter tox
+          python -m pip install --upgrade pip setuptools wheel cookiecutter tox invoke
       - name: "Create repo and test"
         env: 
           TOX_SKIP_ENV: "py3[76]" # Skip other pythons to avoid having to install pyenv
@@ -32,4 +32,4 @@ jobs:
           cd MyProject
           git init
           git add {.[!.]*,*}
-          tox
+          inv run.tests

--- a/{{ cookiecutter.project_name }}/.github/workflows/main.yml
+++ b/{{ cookiecutter.project_name }}/.github/workflows/main.yml
@@ -33,8 +33,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r requirements/requirements_ci.txt
 
-      - name: "Run tox targets for ${{ matrix.python-version }}"
-        run: "python -m tox"
+      - name: "Run tests targets for ${{ matrix.python-version }}"
+        run: "python -m invoke run.tests"
       - name: "Generate coverage XML"
         if: "contains(env.USING_COVERAGE, matrix.python-version)"
         run: python -m coverage xml

--- a/{{ cookiecutter.project_name }}/requirements/requirements_ci.txt
+++ b/{{ cookiecutter.project_name }}/requirements/requirements_ci.txt
@@ -1,2 +1,3 @@
 -r requirements_tests.txt
 tox-gh-actions
+invoke

--- a/{{ cookiecutter.project_name }}/tasks.py
+++ b/{{ cookiecutter.project_name }}/tasks.py
@@ -78,7 +78,7 @@ def run_autoformatters(c):
 
 
 @task(name="tests")
-def run_tests(c, autoformat=True, tox_args=None):
+def run_tests(c, autoformat=False, tox_args=None):
     """
     Run the tests.
     """
@@ -314,10 +314,12 @@ def check_todos(c):
 
 
 @task()
-def release(c, prod=False, clean=True, build=True, skip_tests=False):
+def release(c, prod=False, clean=True, build=True, skip_tests=False, autoformat=True):
     """
     Perform a release to pypi.
     """
+    if autoformat:
+        run_autoformatters(c)
     if not skip_tests:
         run_tests(c)
     if clean:


### PR DESCRIPTION
Preserve the layer of abstraction that invoke inserts when running the
tests in CI.

Makes it so that invoking the tests via invoke doesn't automatically
invoke the autoformatters.

Adds an option to run the autoformatters before releases