### PR TITLE
readthedocs yml v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ tl;dr: A CI enabled Python software project with plenty of bells and whistles.
 - Steps
     - Create a github repo named $YOUR_PROJECT_NAME
     - Enable repository monitoring on readthedocs
-        - Configure "Requirements file" in Admin > Advanced Settings
-            - `requirements/requirements_docs.txt`
-        - Check "Install Project" in Admin > Advanced Settings
     - Enable repository monitoring in pyup
     - ```$ cookiecutter gh:bnbalsamo/cookiecutter-pypackage```
     - Fill in the prompts

--- a/{{ cookiecutter.project_name }}/.readthedocs.yml
+++ b/{{ cookiecutter.project_name }}/.readthedocs.yml
@@ -1,10 +1,25 @@
 # .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-build:
-  image: latest
+# (Required) Use v2 of the rtd yml schema
+version: 2
 
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Configure the docs build env
+# Install docs requirements
+# Install pinned project requirements (if they exist)
+# Install the package with pip
 python:
-  version: 3
-  setup_py_install: true
+  version: 3.8
+  install:
+    - requirements: requirements/requirements_docs.txt
+    - requirements: requirements.txt
+    - method: pip
+      path: .
 
-requirements_file: requirements/requirements_docs.txt
+# Build docs in all formats
+formats: all

--- a/{{ cookiecutter.project_name }}/docs/conf.py
+++ b/{{ cookiecutter.project_name }}/docs/conf.py
@@ -167,12 +167,14 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (main_doc, '{{ cookiecutter.project_name }}', '{{cookiecutter.project_name}} Documentation',
-     author, 'cookiecutterproject_name', 'One line description of project.',
+     author, 'cookiecutterproject_name', '{{ cookiecutter.short_description }}',
      'Miscellaneous'),
 ]
 
 
-
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/3/': None}
+# Example configuration for intersphinx inventory files
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+#    'twisted': ('https://twistedmatrix.com/documents/current/api/', None),
+#    'environ': ('https://environ-config.readthedocs.io/en/stable/', None),
+}


### PR DESCRIPTION
Upgrade the `.readthedocs.yml` in the generated project to use v2 of the
readthedocs yml schema:

https://docs.readthedocs.io/en/stable/config-file/v2.html

Updates the README accordingly, no more manual intervention should be
required on project bootstrapping (besides enabling repository
monitoring)

Adds some examples to the intersphinx inventory section of the config
(commented out) to demonstrate getting inventories from the stdlib,
twisted, and a rtds project.