### PR TITLE
Make names more explicit

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.31.1
+current_version = 0.32.0
 commit = True
 tag = True
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           set -xe
           cookiecutter . --no-input
-          cd MyProject
+          cd My-Project
           git init
           git add {.[!.]*,*}
           inv run.tests

--- a/.github/workflows/make_example_repo.yml
+++ b/.github/workflows/make_example_repo.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Create Example"
         run: |
           set -xe
-          echo -e "bnb-cookiecutter-example\n\n\n\n\n\n\nbnbalsamo\n\n\n\n\n" | cookiecutter .
+          echo -e "bnb-cookiecutter-example\n\n\n\n\n\n\n\nbnbalsamo\n\n\n\n\n" | cookiecutter .
       - name: Push to example repository
         uses: cpina/github-action-push-to-another-repository@master
         env:
@@ -32,5 +32,5 @@ jobs:
         with:
           source-directory: 'bnb-cookiecutter-example'
           destination-github-username: 'bnbalsamo'
-          destination-repository-name: 'bnb_cookiecutter_example'
+          destination-repository-name: 'bnb-cookiecutter-example'
           user-email: 'Brian@BrianBalsamo.com'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.31.1](https://img.shields.io/badge/version-0.31.1-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.32.0](https://img.shields.io/badge/version-0.32.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 My [cookiecutter](https://github.com/audreyr/cookiecutter) template for python packages
 
-[See an example of a generated project here](https://github.com/bnbalsamo/bnb_cookiecutter_example/)
+[See an example of a generated project here](https://github.com/bnbalsamo/bnb-cookiecutter-example/)
 
 # Whats it get me?
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,11 +1,12 @@
 {
-    "project_name": "MyProject",
-    "slug_name": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
+    "project_name": "My-Project",
+    "pip_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
+    "module_name": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
     "version": "0.0.1",
     "short_description": "A project.",
     "author": "First Last",
     "email": "you@provider.com",
-    "github_repo_name": "{{ cookiecutter.slug_name }}",
+    "github_repo_name": "{{ cookiecutter.project_name }}",
     "github_username": "githubber",
     "github_default_branch_name": "master",
     "license": [

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -54,7 +54,7 @@ git init && \\
 git add {.[!.]*,*} && \\
 git commit -m "first commit" && \\
 git remote add origin https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}.git && \\
-git push -u origin {{ cookiecutter.github_default_branch_name }} && \
+git push -u origin {{ cookiecutter.github_default_branch_name }} && \\
 pyenv virtualenv "$PYENV_LATEST_38" "$PROJECT_NAME" && \\
 pyenv local "$PROJECT_NAME" "$PYENV_LATEST_38" "$PYENV_LATEST_37" "$PYENV_LATEST_36" && \\
 pip install -r "requirements/requirements_dev.txt"

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -4,10 +4,20 @@ import sys
 
 MODULE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
 
-module_name = '{{ cookiecutter.slug_name}}'
 
+project_name = '{{ cookiecutter.project_name }}'
+module_name = '{{ cookiecutter.module_name}}'
+
+
+# Check project name
+if re.match(r'\s', project_name):
+    print('ERROR: The project_name (%s) can not contain whitespace.' % project_name)
+    sys.exit(1)
+
+
+# Check module name
 if not re.match(MODULE_REGEX, module_name):
-    print('ERROR: The project slug (%s) is not a valid Python module name. Please do not use a - and use _ instead' % module_name)
+    print('ERROR: The module_name (%s) is not a valid Python module name. Please do not use a - and use _ instead' % module_name)
 
     # Exit to cancel project
     sys.exit(1)

--- a/{{ cookiecutter.project_name }}/.bumpversion.cfg
+++ b/{{ cookiecutter.project_name }}/.bumpversion.cfg
@@ -5,7 +5,7 @@ tag = True
 
 [bumpversion:file:setup.py]
 
-[bumpversion:file:src/{{ cookiecutter.slug_name }}/__init__.py]
+[bumpversion:file:src/{{ cookiecutter.module_name }}/__init__.py]
 
 [bumpversion:file:README.md]
 

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.31.1_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.32.0_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -12,10 +12,10 @@
 See the full documentation at https://{{cookiecutter.github_repo_name }}.readthedocs.io
 {% endif %}
 # Installation
-- ```$ git clone https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.slug_name }}.git```
-- ```$ cd {{ cookiecutter.slug_name }}```
+- ```$ git clone https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}.git```
+- ```$ cd {{ cookiecutter.github_repo_name }}```
     - If you would like to install the pinned dependencies, run ```pip install -r requirements.txt```
-- ```$ python setup.py install```
+- ```$ python -m pip install .```
 
 # Development
 

--- a/{{ cookiecutter.project_name }}/docs/autodoc.rst
+++ b/{{ cookiecutter.project_name }}/docs/autodoc.rst
@@ -1,7 +1,7 @@
 Auto Docs
 =========
 
-.. automodule:: {{ cookiecutter.slug_name }}
+.. automodule:: {{ cookiecutter.module_name }}
    :members:
    :inherited-members:
    :special-members: __init__

--- a/{{ cookiecutter.project_name }}/docs/conf.py
+++ b/{{ cookiecutter.project_name }}/docs/conf.py
@@ -167,7 +167,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (main_doc, '{{ cookiecutter.project_name }}', '{{cookiecutter.project_name}} Documentation',
-     author, 'cookiecutterproject_name', '{{ cookiecutter.short_description }}',
+     author, '{{ cookiecutter.project_name }}', '{{ cookiecutter.short_description }}',
      'Miscellaneous'),
 ]
 

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -27,7 +27,7 @@ ignore = [
 ]
 
 [tool.coverage.run]
-source = ["{{ cookiecutter.slug_name }}"]
+source = ["{{ cookiecutter.module_name }}"]
 
 [tool.coverage.report]
 fail_under = 80

--- a/{{ cookiecutter.project_name }}/setup.py
+++ b/{{ cookiecutter.project_name }}/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 
 # Provided Package Metadata
-NAME = "{{ cookiecutter.slug_name }}"
+NAME = "{{ cookiecutter.pip_name }}"
 DESCRIPTION = "{{ cookiecutter.short_description }}"
 VERSION = "{{ cookiecutter.version }}"
 AUTHOR = "{{ cookiecutter.author }}"
 AUTHOR_EMAIL = "{{ cookiecutter.email }}"
-URL = 'https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.slug_name }}'
+URL = 'https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}'
 PYTHON_REQUIRES= ">=3.6,<4"
 INSTALL_REQUIRES = [
     # Put "abstract" / loosely pinned requirements here

--- a/{{ cookiecutter.project_name }}/src/{{ cookiecutter.module_name }}/__init__.py
+++ b/{{ cookiecutter.project_name }}/src/{{ cookiecutter.module_name }}/__init__.py
@@ -1,4 +1,4 @@
-"""{{ cookiecutter.slug_name }}: {{ cookiecutter.short_description }}"""
+"""{{ cookiecutter.project_name }}: {{ cookiecutter.short_description }}"""
 
 __author__ = "{{ cookiecutter.author }}"
 __email__ = "{{ cookiecutter.email }}"

--- a/{{ cookiecutter.project_name }}/tests/__init__.py
+++ b/{{ cookiecutter.project_name }}/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Unit test module for {{ cookiecutter.slug_name }}."""
+"""Unit test module for {{ cookiecutter.project_name }}."""

--- a/{{ cookiecutter.project_name }}/tests/test_{{ cookiecutter.module_name }}.py
+++ b/{{ cookiecutter.project_name }}/tests/test_{{ cookiecutter.module_name }}.py
@@ -1,12 +1,12 @@
-"""Tests for {{ cookiecutter.slug_name }}."""
+"""Tests for {{ cookiecutter.project_name }}."""
 import pytest
 
-import {{ cookiecutter.slug_name }}
+import {{ cookiecutter.module_name }}
 
 
 def test_version_available():
     """Test the version dunder is available on the module."""
-    x = getattr({{ cookiecutter.slug_name }}, "__version__", None)
+    x = getattr({{ cookiecutter.module_name }}, "__version__", None)
     assert x is not None
 
 

--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -14,7 +14,7 @@ deps =
     -rrequirements/requirements_tests.txt
 commands =
     python -m pip freeze
-    pytest {posargs:--cov={{ cookiecutter.slug_name}}}
+    pytest {posargs:--cov={{ cookiecutter.module_name}}}
 
 [testenv:pinned_deps]
 description = Run unit tests using pinned dependencies
@@ -23,7 +23,7 @@ deps =
     -rrequirements.txt
 commands =
     python -m pip freeze
-    pytest {posargs:--cov={{ cookiecutter.slug_name}}}
+    pytest {posargs:--cov={{ cookiecutter.module_name}}}
 
 [testenv:mypy]
 description = Typecheck the code
@@ -46,7 +46,7 @@ deps =
     isort[pyproject] >= 5.0.0
     pylint >= 2.6.0
 commands =
-    python -m pylint {posargs:src/{{ cookiecutter.slug_name }}}
+    python -m pylint {posargs:src/{{ cookiecutter.module_name }}}
 
 [testenv:pydocstyle]
 description = Check docstrings
@@ -113,7 +113,7 @@ description = Produce pinned requirements.txt
 deps =
 recreate = true
 commands =
-    python -c 'import datetime; from pip._internal.operations import freeze; x = freeze.freeze(skip=["{{ cookiecutter.slug_name }}", "pip", "setuptools", "wheel"]); f = open("requirements.txt", "w"); f.write("# Pinned on " + datetime.datetime.today().strftime("%Y-%m-%d") + "\n"); [f.write(p+"\n") for p in x]'
+    python -c 'import datetime; from pip._internal.operations import freeze; x = freeze.freeze(skip=["{{ cookiecutter.module_name }}", "pip", "setuptools", "wheel"]); f = open("requirements.txt", "w"); f.write("# Pinned on " + datetime.datetime.today().strftime("%Y-%m-%d") + "\n"); [f.write(p+"\n") for p in x]'
 
 [testenv:interrogate]
 description = Check docstring coverage of code


### PR DESCRIPTION
Changes the cookiecutter logic so that names are handled more
explicitly.

The project name is now used for docs + the containing dir name.

The pip name (what your project will be seen as in commands like
`pip freeze` and what you `pip install` after publishing to pypi
is now separately configurable. It defaults to the project name
lowercased.

s/slug_name/module_name/g to be more explicit/use verbiage more common
in python parlance.

Changed the example repo to use a dashed name rather than one with
underscores.

Fixed a bug with the copy-paste-ability of the initial project
bootstrapping script.

Recommends using pip to install the package in the generated README.md
instead of `python setup.py install`.