### PR TITLE
Implement blacken-docs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.33.3
+current_version = 0.34.0
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Available tasks:
   clean.wheelhouse        Remove the wheelhouse.
   run.autoformatters      Run all the autoformatters.
   run.black               Run `black` to autoformat the source code.
+  run.blacken-docs        Run `blacken-docs` to autoformat code in the documentation.
   run.isort               Run `isort` to autoformat the source code.
   run.tests               Run the tests.
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.33.3](https://img.shields.io/badge/version-0.33.3-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.34.0](https://img.shields.io/badge/version-0.34.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.33.3_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.34.0_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/setup.py
+++ b/{{ cookiecutter.project_name }}/setup.py
@@ -29,6 +29,7 @@ EXTRAS_REQUIRE = {
         "wheel",
         "pep517",
         "twine",
+        "blacken-docs",
     ],
     "tests": [
         "tox",


### PR DESCRIPTION
Adds [`blacken-docs`](https://github.com/asottile/blacken-docs) to the
autoformatters.

This closes #18

Note that `blacken-docs` doesn't support a `--check` option, so it
doesn't mesh very well with the current CI setup, and so is omitted from
the tox configuration.

Additionally - swaps the autoformatters over to allow non-zero exit
codes when started via invoke by default.