### PR TITLE
Add relevant diff output to CI

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.34.0
+current_version = 0.34.1
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.34.0](https://img.shields.io/badge/version-0.34.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.34.1](https://img.shields.io/badge/version-0.34.1-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.34.0_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.34.1_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -86,7 +86,7 @@ deps =
     isort[pyproject] >= 5.0.0
 extras =
 commands =
-    python -m isort -c {posargs:--diff src tests}
+    python -m isort --diff -c {posargs:--diff src tests}
 
 [testenv:check_black]
 description = Check code formatting
@@ -94,7 +94,7 @@ skip_install = true
 deps =
     black
 commands =
-    python -m black --check {posargs:src tests}
+    python -m black --diff --check {posargs:src tests}
 
 [testenv:docs]
 description = Build sphinx documentation


### PR DESCRIPTION
Adds `--diff` flags to `black` and `isort` checks in tox.

This should make the output of CI runs more self explanatory and avoid
having to re-run those tools locally to examine proposed changes.