### PR TITLE
Switch copy/paste setup to use SSH

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.36.0
+current_version = 0.37.0
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.37.0
+current_version = 0.37.1
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ tl;dr: A CI enabled Python software project with plenty of bells and whistles.
 - Requirements For These Instructions
     - [Cookiecutter](https://github.com/audreyr/cookiecutter)
     - [Github](https://github.com/) account
+        - [With SSH access configured](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)
     - [CodeCov](https://codecov.io/) account
     - [readthedocs](https://readthedocs.org/) account
     - [pyup](https://pyup.io/) account

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.37.0](https://img.shields.io/badge/version-0.37.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.37.1](https://img.shields.io/badge/version-0.37.1-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.36.0](https://img.shields.io/badge/version-0.36.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.37.0](https://img.shields.io/badge/version-0.37.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -53,7 +53,7 @@ cd $PROJECT_NAME && \\
 git init && \\
 git add {.[!.]*,*} && \\
 git commit -m "first commit" && \\
-git remote add origin https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}.git && \\
+git remote add origin git@github.com:{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}.git && \\
 git push -u origin {{ cookiecutter.github_default_branch_name }} && \\
 pyenv virtualenv "$PYENV_LATEST_38" "$PROJECT_NAME" && \\
 pyenv local "$PROJECT_NAME" "$PYENV_LATEST_38" "$PYENV_LATEST_37" "$PYENV_LATEST_36" && \\

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.36.0_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.37.0_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.37.0_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.37.1_
 {% endif -%}


### PR DESCRIPTION
Github is [deprecating password access for git
operations](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/).

This change switches the copy/pastable setup instructions to use ssh
for the remote protocol, which will continue to work.