### PR TITLE
Switch to `build` from `pep517`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.37.1
+current_version = 0.38.0
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.37.1](https://img.shields.io/badge/version-0.37.1-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.38.0](https://img.shields.io/badge/version-0.38.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.37.1_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.38.0_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/setup.py
+++ b/{{ cookiecutter.project_name }}/setup.py
@@ -27,7 +27,7 @@ EXTRAS_REQUIRE = {
         "pylint >= 2.6.0",
         "black",
         "wheel",
-        "pep517",
+        "build >= 0.2.1",
         "twine",
         "blacken-docs",
     ],

--- a/{{ cookiecutter.project_name }}/tasks.py
+++ b/{{ cookiecutter.project_name }}/tasks.py
@@ -294,7 +294,7 @@ def build_dists(c, clean=True):
     if clean:
         clean_dists(c)
     echo("Building dists...")
-    c.run("python -m pep517.build -s -b .")
+    c.run("python -m build -s -w .")
     echo(f"Dists now available in {Path('./dist').resolve()}")
 
 

--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -138,8 +138,8 @@ commands =
 description = Check the package builds
 skip_install = true
 deps =
-    pep517
+    build
     twine
 commands =
-    python -m pep517.build -s -b .
+    python -m build -s -w .
     python -m twine check dist/*


### PR DESCRIPTION
The [pep517 utility] is only a proof of concept pep517 implementation
and has [deprecated its high level script
functionality](https://github.com/pypa/pep517#deprecated-high-level).

The [build](https://pypa-build.readthedocs.io/en/latest/index.html)
project from the PyPA is the suggested replacement.