### PR TITLE
Fix checkdeps_install

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.38.0
+current_version = 0.38.1
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.38.0](https://img.shields.io/badge/version-0.38.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.38.1](https://img.shields.io/badge/version-0.38.1-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.38.0_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.38.1_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -79,6 +79,7 @@ deps =
     safety
 extras =
 commands =
+    python -m pip install --progress-bar off -U pip setuptools wheel
     python -m safety check {posargs}
 
 [testenv:check_isort]


### PR DESCRIPTION
Fixes an issue where if `safety` outpaces `virtualenv` it is possible
for the `checkdeps_install` tox environment to fail on the version of
pip, setuptools, or wheel.

See PR #57 (closed) for more information/context.