### PR TITLE
Adding doc8

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.38.2
+current_version = 0.38.3
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.38.3
+current_version = 0.38.4
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -234,5 +234,7 @@ Inspiration (and some code) taken from the following:
 * [Kyle Knapp's talk @ PyCon 2018 "Automating Code Quality"](https://www.youtube.com/watch?v=G1lDk_WKXvY)
 * [Hynek's blog post "Sharing Your Labor of Love: PyPI Quick and Dirty"](https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/)
 * [Hynek's blog post "Python in GitHub Actions](https://hynek.me/articles/python-github-actions/)
+* [Kyle Knapp's talk @ PyGotham 2018 "Automating Code Quality: Next Level](https://www.youtube.com/watch?v=iKAaNaVpJFM)
+* [Thea Flowers' talk @ PyCon 2019 "Break the Cycle: Three excellent Python tools to automate repetitive tasks"](https://www.youtube.com/watch?v=-BHverY7IwU)
 * Everyone writing blog posts/github issues/mailing list responses/twitter rants/etc about Python packaging, best practices, and development workflows
 * All the wonderful folks writing the tools and services involved in this template and their documentation!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.38.2](https://img.shields.io/badge/version-0.38.2-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.38.3](https://img.shields.io/badge/version-0.38.3-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.38.3](https://img.shields.io/badge/version-0.38.3-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.38.4](https://img.shields.io/badge/version-0.38.4-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.38.2_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.38.3_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.38.3_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.38.4_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py38,py37,py36,pinned_deps,flake8,pylint,pydocstyle,check_isort,check_black,bandit,checkdeps_requirements.txt,checkdeps_install,docs,checkmanifest,mypy,interrogate,interrogate_tests,build
+envlist = py38,py37,py36,pinned_deps,flake8,pylint,pydocstyle,check_isort,check_black,bandit,checkdeps_requirements.txt,checkdeps_install,docs_style,docs,docs_linkcheck,checkmanifest,mypy,interrogate,interrogate_tests,build
 isolated_build_env = true
 
 [gh-actions]
 python =
-    3.8: py38,pinned_deps,flake8,pydocstyle,bandit,check_isort,check_black,docs,checkmanifest,mypy,interrogate,interrogate_tests,build
+    3.8: py38,pinned_deps,flake8,pylint,pydocstyle,check_isort,check_black,bandit,checkdeps_requirements.txt,checkdeps_install,docs_style,docs,docs_linkcheck,checkmanifest,mypy,interrogate,interrogate_tests,build
     3.7: py37,checkdeps_install,build
     3.6: py36,checkdeps_install,build
 
@@ -37,6 +37,7 @@ description = Lint the code and tests
 skip_install = true
 deps =
     flake8
+    pep8-naming
 commands =
     python -m flake8 {posargs:src tests}
 
@@ -97,6 +98,15 @@ deps =
     black
 commands =
     python -m black --diff --check {posargs:src tests}
+
+[testenv:docs_style]
+description = Check the docs for style
+extras =
+skip_install = true
+deps =
+    doc8
+commands =
+    doc8 --max-line-length 88 docs
 
 [testenv:docs]
 description = Build sphinx documentation


### PR DESCRIPTION
Added doc8 and pep8-naming to the static analysis.

Fixed an error in the tox configuration that meant that some of the
previously added checks (`docs_style` and `docs_linkcheck`) weren't
running.