### PR TITLE
Use pip-compile to pin dependencies

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.38.4
+current_version = 0.38.5
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.38.4](https://img.shields.io/badge/version-0.38.4-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.38.5](https://img.shields.io/badge/version-0.38.5-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.38.4_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.38.5_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/setup.py
+++ b/{{ cookiecutter.project_name }}/setup.py
@@ -30,6 +30,7 @@ EXTRAS_REQUIRE = {
         "build >= 0.2.1",
         "twine",
         "blacken-docs",
+        "pip-tools",
     ],
     "tests": [
         "tox",

--- a/{{ cookiecutter.project_name }}/tasks.py
+++ b/{{ cookiecutter.project_name }}/tasks.py
@@ -30,15 +30,22 @@ def echo(msg):
 
 
 @task(name="pindeps")
-def _pindeps(c):
+def _pindeps(c, generate_hashes=True, upgrade=True, pip_compile_args=""):
     """
-    Pin dependencies, creating or overwriting requirements.txt
+    Pin dependencies.
     """
     # Requires being run in a fresh virtualenv,
     # so we leverage tox
     echo("Pinning dependencies...")
-    c.run("tox -e pindeps --recreate")
-    # This must be in sync with tox.ini
+    argv = ["pip-compile"]
+    if generate_hashes:
+        argv.append("--generate-hashes")
+    if upgrade:
+        argv.append("-U")
+    if pip_compile_args:
+        argv.append(pip_compile_args)
+    os.environ["CUSTOM_COMPILE_COMMAND"] = "inv[oke] pindeps"
+    c.run(" ".join(argv))
     req_path = Path(".") / "requirements.txt"
     req_path = req_path.resolve()
     echo(f"Dependencies pinned in {str(req_path)}")

--- a/{{ cookiecutter.project_name }}/tox.ini
+++ b/{{ cookiecutter.project_name }}/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py38,py37,py36,pinned_deps,flake8,pylint,pydocstyle,check_isort,check_black,bandit,checkdeps_requirements.txt,checkdeps_install,docs_style,docs,docs_linkcheck,checkmanifest,mypy,interrogate,interrogate_tests,build
 isolated_build_env = true
 
 [gh-actions]
 python =
-    3.8: py38,pinned_deps,flake8,pylint,pydocstyle,check_isort,check_black,bandit,checkdeps_requirements.txt,checkdeps_install,docs_style,docs,docs_linkcheck,checkmanifest,mypy,interrogate,interrogate_tests,build
+    3.8:
     3.7: py37,checkdeps_install,build
     3.6: py36,checkdeps_install,build
 
@@ -127,13 +126,6 @@ deps =
 extras =
 commands =
     python -m check_manifest {posargs}
-
-[testenv:pindeps]
-description = Produce pinned requirements.txt
-extras =
-recreate = true
-commands =
-    python -c 'import datetime; from pip._internal.operations import freeze; x = freeze.freeze(skip=["{{ cookiecutter.pip_name }}", "pip", "setuptools", "wheel", "distribute"]); f = open("requirements.txt", "w"); f.write("# Pinned on " + datetime.datetime.today().strftime("%Y-%m-%d") + "\n"); [f.write(p+"\n") for p in x]'
 
 [testenv:interrogate]
 description = Check docstring coverage of code


### PR DESCRIPTION
Uses pip-compile in order to generate `requirements.txt` instead of a
tox environment.

This simplifies the tox config because it now only contains testing
environments, while the `tasks.py` now contains all the automation
logic.