### PR TITLE
Tasks changes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.38.7
+current_version = 0.39.0
 commit = True
 tag = True
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           inv build.dists
           inv build.docs
           inv build.wheelhouse
-          inv build.coverage-report
+          inv build.coverage-report --no-test
           inv clean
           inv clean.all
           inv check.todos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           set -xe
           python -VV
           python -m site
-          python -m pip install --upgrade pip setuptools wheel cookiecutter tox invoke
+          python -m pip install --upgrade pip setuptools wheel cookiecutter
       - name: "Create repo and test"
         env: 
           TOX_SKIP_ENV: "py3[76]" # Skip other pythons to avoid having to install pyenv
@@ -32,4 +32,13 @@ jobs:
           cd My-Project
           git init
           git add {.[!.]*,*}
+          pip install .[dev,tests,docs]
           inv run.tests
+          inv build
+          inv build.dists
+          inv build.docs
+          inv build.wheelhouse
+          inv build.coverage-report
+          inv clean
+          inv clean.all
+          inv check.todos

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.38.7](https://img.shields.io/badge/version-0.38.7-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.39.0](https://img.shields.io/badge/version-0.39.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/README.md
+++ b/README.md
@@ -108,14 +108,14 @@ Any of the following can be run off the bat from the project root, via `invoke`/
 $ inv --list
 Available tasks:
 
-  pindeps                 Pin dependencies, creating or overwriting requirements.txt
+  pindeps                 Pin dependencies.
   release                 Perform a release to pypi.
   build.coverage-report   Build an HTML coverage report.
-  build.dists             Build distribution artifacts.
+  build.dists (build)     Build distribution artifacts.
   build.docs              Build the documentation.
   build.wheelhouse        Build a dependency wheelhouse.
   check.todos             Check for `#TODO` comments in the code.
-  clean.all               Remove all clean-able artifacts.
+  clean.all (clean)       Remove all clean-able artifacts.
   clean.compiled          Remove compilation artifacts.
   clean.coverage          Remove the .coverage cache.
   clean.coverage-report   Remove the html coverage report.
@@ -129,6 +129,7 @@ Available tasks:
   run.blacken-docs        Run `blacken-docs` to autoformat code in the documentation.
   run.isort               Run `isort` to autoformat the source code.
   run.tests               Run the tests.
+  serve.docs              Serve the docs on localhost:8000. Reload on changes.
 ```
 
 Additional information about commands can be obtained by using their `--help` flag, eg:

--- a/{{ cookiecutter.project_name }}/.github/PULL_REQUEST_TEMPLATE.md
+++ b/{{ cookiecutter.project_name }}/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 # Closes Issues
+
 * Fixes #...
 * ...
 
@@ -19,7 +20,7 @@ will need to pass in order for your code to be merged.
 If you have any questions about the points below please ask them
 in a comment on this pull request!
 
-This checklist is meant to make the process of conributing easier, not harder!
+This checklist is meant to make the process of contributing easier, not harder!
 
 - [ ] Added tests for changed code
 - [ ] Updated documentation for changed code

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.38.7_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.39.0_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/setup.py
+++ b/{{ cookiecutter.project_name }}/setup.py
@@ -31,6 +31,7 @@ EXTRAS_REQUIRE = {
         "twine",
         "blacken-docs",
         "pip-tools",
+        "sphinx-autobuild",
     ],
     "tests": [
         "tox",

--- a/{{ cookiecutter.project_name }}/tasks.py
+++ b/{{ cookiecutter.project_name }}/tasks.py
@@ -283,7 +283,7 @@ def build_dists(c, clean=True):
 
 
 @task(name="wheelhouse")
-def build_wheelhouse(c, clean=True, pin_depencies=True):
+def build_wheelhouse(c, clean=True, pin_dependencies=True):
     """
     Build a dependency wheelhouse.
     """

--- a/{{ cookiecutter.project_name }}/tasks.py
+++ b/{{ cookiecutter.project_name }}/tasks.py
@@ -124,7 +124,6 @@ def remove_directory(directory, raise_=False):
             raise FileNotFoundError(directory)
         echo(f"No directory found at {str(directory)}")
         return
-    echo(f"Removing {str(directory)}")
     rmtree(directory)
     echo(f"{str(directory)} removed.")
 
@@ -199,7 +198,6 @@ def clean_coverage(c):
     """
     coverage_cache_file = Path("./.coverage").resolve()
     if coverage_cache_file.exists() and coverage_cache_file.is_file():
-        echo(f"Removing {str(coverage_cache_file)}")
         coverage_cache_file.unlink()
         echo(f"{str(coverage_cache_file)} removed.")
     else:
@@ -277,7 +275,6 @@ def build_dists(c, clean=True):
     if clean:
         clean_dists(c)
         clean_build_dir(c)
-    echo("Building dists")
     c.run("python -m build -s -w .")
     echo(f"Dists now available in {Path('./dist').resolve()}")
 
@@ -291,7 +288,6 @@ def build_wheelhouse(c, clean=True, pin_dependencies=True):
         clean_wheelhouse(c)
     if pin_dependencies:
         pindeps(c)
-    echo("Creating wheelhouse")
     c.run("python -m pip wheel -w wheelhouse -r requirements.txt")
     echo(f"Wheelhouse now available in {Path('./wheelhouse').resolve()}")
 
@@ -305,7 +301,6 @@ def build_coverage_report(c, clean=True, test=True):
         clean_coverage_report(c)
     if test:
         run_tests(c, warn=True)
-    echo("Creating coverage report")
     c.run("coverage html")
     echo(f"Coverage report available at {str(Path('./htmlcov').resolve())}")
 

--- a/{{ cookiecutter.project_name }}/tasks.py
+++ b/{{ cookiecutter.project_name }}/tasks.py
@@ -25,18 +25,15 @@ ECHO_PREFIX = "=> "
 
 
 def echo(msg):
-    # Wrap print to append a prefix
+    # Wrap print to prepend a prefix
     print(ECHO_PREFIX + str(msg))
 
 
 @task(name="pindeps")
-def _pindeps(c, generate_hashes=True, upgrade=True, pip_compile_args=""):
+def pindeps(c, generate_hashes=True, upgrade=True, pip_compile_args=""):
     """
     Pin dependencies.
     """
-    # Requires being run in a fresh virtualenv,
-    # so we leverage tox
-    echo("Pinning dependencies...")
     argv = ["pip-compile"]
     if generate_hashes:
         argv.append("--generate-hashes")
@@ -52,68 +49,60 @@ def _pindeps(c, generate_hashes=True, upgrade=True, pip_compile_args=""):
 
 
 @task(name="black")
-def run_black(c, warn=True):
+def run_black(c, warn=False):
     """
     Run `black` to autoformat the source code.
     """
     # The result of this command should satisfy the
     # corresponding tox testenv check_black
-    echo("Running black...")
     c.run("python -m black ./src ./tests", warn=warn)
-    echo("Blackening complete")
 
 
 @task(name="blacken_docs")
-def run_blacken_docs(c, warn=True):
+def run_blacken_docs(c, warn=False):
     """
     Run `blacken-docs` to autoformat code in the documentation.
     """
-    echo("Running blacken-docs...")
+    # The result of this command should satisfy the
+    # corresponding tox testenv check_blacken_docs
     docs_paths = ["README.md"]
     docs_paths += glob("docs/**/*.rst", recursive=True)
     docs_paths += glob("src/**/*.py", recursive=True)
     docs_paths = [quote(p) for p in docs_paths]
     c.run("blacken-docs %s" % " ".join(docs_paths), warn=warn)
-    echo("Blackening complete")
 
 
 @task(name="isort")
-def run_isort(c, warn=True):
+def run_isort(c, warn=False):
     """
     Run `isort` to autoformat the source code.
     """
     # The result of this command should satisfy the
     # corresponding tox testenv check_isort
-    echo("Running isort...")
     c.run("python -m isort ./src ./tests", warn=warn)
-    echo("Isort-ing complete")
 
 
 @task(name="autoformatters")
-def run_autoformatters(c, warn=True):
+def run_autoformatters(c, warn=False):
     """
     Run all the autoformatters.
     """
-    echo("Running all autoformatters...")
     run_black(c, warn=warn)
     run_blacken_docs(c, warn=warn)
     run_isort(c, warn=warn)
-    echo("Autoformatting complete")
 
 
 @task(name="tests")
-def run_tests(c, autoformat=False, tox_args=None):
+def run_tests(c, autoformat=True, tox_args=None, warn=False):
     """
     Run the tests.
     """
-    echo("Running tests...")
     if autoformat:
-        run_autoformatters(c)
+        run_autoformatters(c, warn=warn)
     cmd = "tox"
     if tox_args:
         cmd = cmd + " %s" % tox_args
-    c.run(cmd)
-    echo("Testing complete")
+    c.run(cmd, warn=warn)
 
 
 @task(name="docs")
@@ -121,7 +110,6 @@ def build_docs(c, clean=True, buildername="html"):
     """
     Build the documentation.
     """
-    echo("Building docs...")
     if clean:
         clean_docs(c)
     c.run(f"sphinx-build docs docs_out --color -W -b{buildername}")
@@ -130,22 +118,24 @@ def build_docs(c, clean=True, buildername="html"):
     echo(f"Docs available in {str(docs_dir)}")
 
 
+def remove_directory(directory, raise_=False):
+    if not directory.exists():
+        if raise_:
+            raise FileNotFoundError(directory)
+        echo(f"No directory found at {str(directory)}")
+        return
+    echo(f"Removing {str(directory)}")
+    rmtree(directory)
+    echo(f"{str(directory)} removed.")
+
+
 @task(name="dists")
 def clean_dists(c):
     """
     Remove existing distributions.
     """
     dist_dir = Path("./dist").resolve()
-    if not dist_dir.exists():
-        echo(f"No dist dir found at {str(dist_dir)}")
-        return
-    if not dist_dir.is_dir():
-        raise NotADirectoryError(dist_dir)
-    echo(f"Removing existing dist dir: {str(dist_dir)}...")
-    for contents in dist_dir.iterdir():
-        contents.unlink()
-    dist_dir.rmdir()
-    echo("Dist dir removed")
+    remove_directory(dist_dir)
 
 
 @task(name="docs")
@@ -154,14 +144,7 @@ def clean_docs(c):
     Remove existing docs.
     """
     docs_out_dir = Path("./docs_out").resolve()
-    if not docs_out_dir.exists():
-        echo(f"No rendered docs dir found at {str(docs_out_dir)}")
-        return
-    if not docs_out_dir.is_dir():
-        raise NotADirectoryError(docs_out_dir)
-    echo(f"Removing existing rendered docs dir: {str(docs_out_dir)}...")
-    rmtree(docs_out_dir)
-    echo("Rendered docs directory removed")
+    remove_directory(docs_out_dir)
 
 
 @task(name="compiled")
@@ -174,6 +157,7 @@ def clean_compiled(c):
         for entry in d.iterdir():
             if entry.name.endswith(".pyc"):
                 entry.unlink()
+                continue
             if entry.name == "__pycache__" or entry.name.endswith(".egg-info"):
                 rmtree(entry)
                 continue
@@ -185,7 +169,7 @@ def clean_compiled(c):
         Path("./tests").resolve(),
     ]
     for d in dirs_to_clean:
-        echo(f"Removing compiled/cache artifacts in {str(d)}...")
+        echo(f"Removing compiled/cache artifacts in {str(d)}")
         clean_dir(d)
     echo("Compiled artifacts and caches removed")
 
@@ -196,12 +180,7 @@ def clean_tox(c):
     Remove the .tox cache directory.
     """
     tox_dir = Path("./.tox").resolve()
-    if tox_dir.exists() and tox_dir.is_dir():
-        echo(f"Removing tox cache: {str(tox_dir)}...")
-        rmtree(tox_dir)
-        echo("Tox cache removed")
-    else:
-        echo(f"No docs cache dir found at {str(tox_dir)}")
+    remove_directory(tox_dir)
 
 
 @task(name="mypy")
@@ -210,12 +189,7 @@ def clean_mypy(c):
     Remove the .mypy_cache directory.
     """
     mypy_cache_dir = Path("./.mypy_cache").resolve()
-    if mypy_cache_dir.exists() and mypy_cache_dir.is_dir():
-        echo(f"Removing mypy cache: {str(mypy_cache_dir)}...")
-        rmtree(mypy_cache_dir)
-        echo("Mypy cache removed")
-    else:
-        echo(f"No mypy cache dir found at {str(mypy_cache_dir)}")
+    remove_directory(mypy_cache_dir)
 
 
 @task(name="coverage")
@@ -225,11 +199,11 @@ def clean_coverage(c):
     """
     coverage_cache_file = Path("./.coverage").resolve()
     if coverage_cache_file.exists() and coverage_cache_file.is_file():
-        echo(f"Removing coverage cache: {str(coverage_cache_file)}...")
+        echo(f"Removing {str(coverage_cache_file)}")
         coverage_cache_file.unlink()
-        echo("Coverage cache removed")
+        echo(f"{str(coverage_cache_file)} removed.")
     else:
-        echo(f"No coverage cache file found at {str(coverage_cache_file)}")
+        echo(f"No file found at {str(coverage_cache_file)}")
 
 
 @task(name="wheelhouse")
@@ -238,12 +212,7 @@ def clean_wheelhouse(c):
     Remove the wheelhouse.
     """
     wheelhouse_dir = Path("./wheelhouse").resolve()
-    if wheelhouse_dir.exists() and wheelhouse_dir.is_dir():
-        echo(f"Removing wheelhouse dir: {str(wheelhouse_dir)}...")
-        rmtree(wheelhouse_dir)
-        echo("Wheelhouse removed")
-    else:
-        echo(f"No wheelhouse dir found at {str(wheelhouse_dir)}")
+    remove_directory(wheelhouse_dir)
 
 
 @task(name="coverage-report")
@@ -252,12 +221,16 @@ def clean_coverage_report(c):
     Remove the html coverage report.
     """
     coverage_report_dir = Path("./htmlcov").resolve()
-    if coverage_report_dir.exists() and coverage_report_dir.is_dir():
-        echo(f"Removing coverage report dir: {str(coverage_report_dir)}...")
-        rmtree(coverage_report_dir)
-        echo("Coverage report dir removed")
-    else:
-        echo(f"No coverage report dir found at {str(coverage_report_dir)}")
+    remove_directory(coverage_report_dir)
+
+
+@task(name="build-dir")
+def clean_build_dir(c):
+    """
+    Remove the build directory.
+    """
+    build_directory = Path("./build").resolve()
+    remove_directory(build_directory)
 
 
 @task(name="all")
@@ -271,6 +244,7 @@ def clean_all(
     coverage=True,
     wheelhouse=True,
     coverage_report=True,
+    build_directory=True,
 ):
     """
     Remove all clean-able artifacts.
@@ -291,6 +265,8 @@ def clean_all(
         clean_wheelhouse(c)
     if coverage_report:
         clean_coverage_report(c)
+    if build_directory:
+        clean_build_dir(c)
 
 
 @task(name="dists")
@@ -300,31 +276,36 @@ def build_dists(c, clean=True):
     """
     if clean:
         clean_dists(c)
-    echo("Building dists...")
+        clean_build_dir(c)
+    echo("Building dists")
     c.run("python -m build -s -w .")
     echo(f"Dists now available in {Path('./dist').resolve()}")
 
 
 @task(name="wheelhouse")
-def build_wheelhouse(c, pindeps=True):
+def build_wheelhouse(c, clean=True, pin_depencies=True):
     """
     Build a dependency wheelhouse.
     """
-    if pindeps:
-        _pindeps(c)
-    echo("Creating wheelhouse...")
+    if clean:
+        clean_wheelhouse(c)
+    if pin_dependencies:
+        pindeps(c)
+    echo("Creating wheelhouse")
     c.run("python -m pip wheel -w wheelhouse -r requirements.txt")
     echo(f"Wheelhouse now available in {Path('./wheelhouse').resolve()}")
 
 
 @task(name="coverage-report")
-def build_coverage_report(c, test=True):
+def build_coverage_report(c, clean=True, test=True):
     """
     Build an HTML coverage report.
     """
+    if clean:
+        clean_coverage_report(c)
     if test:
-        run_tests(c)
-    echo("Creating coverage report...")
+        run_tests(c, warn=True)
+    echo("Creating coverage report")
     c.run("coverage html")
     echo(f"Coverage report available at {str(Path('./htmlcov').resolve())}")
 
@@ -342,23 +323,29 @@ def release(c, prod=False, clean=True, build=True, skip_tests=False, autoformat=
     """
     Perform a release to pypi.
     """
-    if autoformat:
-        run_autoformatters(c)
     if not skip_tests:
-        run_tests(c)
+        run_tests(c, autoformat=autoformat)
     if clean:
         clean_dists(c)
     if build:
         build_dists(c)
     cmd = "python -m twine upload"
     if not prod:
-        echo("Uploading to test.pypi...")
+        echo("Uploading to test.pypi")
         cmd += " --repository-url https://test.pypi.org/legacy"
     else:
-        echo("--prod flag present. Uploading to pypi...")
+        echo("--prod flag present. Uploading to pypi")
     cmd += " ./dist/*"
     c.run(cmd)
     echo("Upload complete")
+
+
+@task(name="docs")
+def serve_docs(c):
+    """
+    Serve the docs on localhost:8000. Reload on changes.
+    """
+    c.run("sphinx-autobuild --watch src docs docs/_build/html")
 
 
 # Make implicit root explicit
@@ -368,29 +355,30 @@ ns.configure({"run": {"pty": True, "echo": True}})
 
 
 # Root commands
-ns.add_task(_pindeps)
+ns.add_task(pindeps)
 ns.add_task(release)
 
 
 # Define the "run" subcommand
 run_ns = Collection("run")
+run_ns.add_task(run_autoformatters)
 run_ns.add_task(run_black)
 run_ns.add_task(run_blacken_docs)
 run_ns.add_task(run_isort)
 run_ns.add_task(run_tests)
-run_ns.add_task(run_autoformatters)
 
 
 # Define the "build" subcommand
 build_ns = Collection("build")
+build_ns.add_task(build_dists, default=True)
 build_ns.add_task(build_docs)
-build_ns.add_task(build_dists)
 build_ns.add_task(build_wheelhouse)
 build_ns.add_task(build_coverage_report)
 
 
 # Define the "clean" subcommand
 clean_ns = Collection("clean")
+clean_ns.add_task(clean_all, default=True)
 clean_ns.add_task(clean_dists)
 clean_ns.add_task(clean_docs)
 clean_ns.add_task(clean_compiled)
@@ -399,7 +387,6 @@ clean_ns.add_task(clean_mypy)
 clean_ns.add_task(clean_coverage)
 clean_ns.add_task(clean_wheelhouse)
 clean_ns.add_task(clean_coverage_report)
-clean_ns.add_task(clean_all)
 
 
 # Define the "check" subcommand
@@ -407,8 +394,14 @@ check_ns = Collection("check")
 check_ns.add_task(check_todos)
 
 
+# Define the "serve" subcommand
+serve_ns = Collection("serve")
+serve_ns.add_task(serve_docs)
+
+
 # Add custom subcommands to root namespace
 ns.add_collection(run_ns)
 ns.add_collection(build_ns)
 ns.add_collection(clean_ns)
 ns.add_collection(check_ns)
+ns.add_collection(serve_ns)


### PR DESCRIPTION
Updates the `tasks.py` invoke tasks to be slightly better organized.

- Removed some superfluous `echo` statements
- Renames `_pindeps` to `pindeps`, changing flags where necessary.
- Sets `warn` appropriately on the tests, so failing autoformatters or
  test runs won't stop coverage reports from being generated.
- Abstracted some shared functionality from the clean tasks into a
  separate function
- Adds a clean task for the build directory
- All relevant `build` commands now perform a clean first by default
- Sets defaults for the `build` and `clean` subparsers

Additionally, adds a new `inv serve.docs` command to dynamically build
and serve the docs, autorefreshing on changes to the docs or source.

Fixes a minor typo in the pull request template as well.