### PR TITLE
Add an option for strong type checking

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.40.0
+current_version = 0.41.0
 commit = True
 tag = True
 

--- a/.github/workflows/make_example_repo.yml
+++ b/.github/workflows/make_example_repo.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Create Example"
         run: |
           set -xe
-          echo -e "bnb-cookiecutter-example\n\n\n\n\n\n\n\nbnbalsamo\n\n\n\n\n" | cookiecutter .
+          echo -e "bnb-cookiecutter-example\n\n\n\n\n\n\n\nbnbalsamo\n\n\n\n\n\n" | cookiecutter .
       - name: Push to example repository
         uses: cpina/github-action-push-to-another-repository@master
         env:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.40.0](https://img.shields.io/badge/version-0.40.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.41.0](https://img.shields.io/badge/version-0.41.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ tl;dr: A CI enabled Python software project with plenty of bells and whistles.
 |github_username|githubber|Used to derive the github URL of the project|
 |github_default_branch_name|master (See [#45](https://github.com/bnbalsamo/cookiecutter-pypackage/issues/45))|Used for the CI badge and in the instructions for project bootstrapping|
 |license|GNU GPLv3|The license to release the project under|
-|create_docs_folder|y|Whether or not to create a separate docs folder for sphinx style documentation.|
-|include_link_back_to_cookiecutter|y|Whether or not to include a link back this cookiecutter in the generated project's `README.md`|
+|create_docs_folder|y|If set to `y` a docs folder will be created for sphinx style documentation.|
+|enforce_strong_typing|n|If set to `y` mypy will error on untyped defs.|
+|include_link_back_to_cookiecutter|y|If set to `y`the generated project's `README.md` will include a link back this cookiecutter.|
 
 
 # Preconfigured Invoke Tasks 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -20,5 +20,6 @@
         "None/Other"
     ],
     "create_docs_folder": "y",
+    "enforce_strong_typing": "n",
     "include_link_back_to_cookiecutter": "y"
 }

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.40.0_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.41.0_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/mypy.ini
+++ b/{{ cookiecutter.project_name }}/mypy.ini
@@ -1,3 +1,14 @@
 [mypy]
 warn_unused_configs=True
 ignore_missing_imports=True
+{% if cookiecutter.enforce_strong_typing == "y" -%}
+disallow_untyped_defs = True
+{%- endif %}
+# https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-type-hints-for-third-party-library
+# Uncomment only as a last resort!
+#ignore_missing_imports = True
+
+# If using untyped libs...
+# Examaple of ignoring imports from an untyped library "foobar"
+#[mypy-foobar.*]
+#ignore_missing_imports = True


### PR DESCRIPTION
- Adds an option to enable `mypy`'s `disallow_untyped_defs` option.
- Adds some helpful (commented) logic to `mypy.ini` for tolerating
  untyped dependencies.
- Adds relevant documentation to the `README.md`.
- Adds required newline to the `make_example_repo` workflow
- Updates language in `README.md` for "booleans" to be more explicit.