### PR TITLE
Docs Update

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.41.1
+current_version = 0.42.0
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cookiecutter-pypackage [![v0.41.1](https://img.shields.io/badge/version-0.41.1-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
+# cookiecutter-pypackage [![v0.42.0](https://img.shields.io/badge/version-0.42.0-blue.svg)](https://github.com/bnbalsamo/cookiecutter-pypackage/releases)
 
 [![CI](https://github.com/bnbalsamo/cookiecutter-pypackage/workflows/CI/badge.svg?branch=master)](https://github.com/bnbalsamo/cookiecutter-pypackage/actions)
 

--- a/README.md
+++ b/README.md
@@ -29,21 +29,27 @@ tl;dr: A CI enabled Python software project with plenty of bells and whistles.
 - [pyup](https://pyup.io/) integration
 - [Invoke](http://www.pyinvoke.org/) tasks to standardize development workflows, including...
     - Running the tests
-    - Running autoformatters like black and isort
+    - Running autoformatters like black, isort, etc.
     - Easily checking `#TODO` comments
     - Building documentation
+    - Serving documentation locally during development
     - Pinning dependencies to a `requirements.txt`
     - Releasing to pypi
     - Building source distributions and wheels
     - Building wheelhouses of your project's dependencies
+    - Cleaning up your development environment
 - A `README.md` that includes...
     - A brief project description
     - Installation instructions
     - relevant badges
     - Easy to follow directions for contributors
 - (optional) [Sphinx](http://www.sphinx-doc.org) documentation
-    - With a minimal autodocs setup
     - Ready for use with [readthedocs](https://readthedocs.org/)
+    - Preconfigured with several staple sphinx extensions
+        - [autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html)
+        - [intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html)
+        - [todo](https://www.sphinx-doc.org/en/master/usage/extensions/todo.html)
+        - [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/)
 - All the tooling you can shake a stick at, wrapped up in a ```tox``` config, properly configured to work together in harmony.
     - [pytest](https://docs.pytest.org/en/latest/)
     - [flake8](http://flake8.pycqa.org/en/latest/)
@@ -55,8 +61,14 @@ tl;dr: A CI enabled Python software project with plenty of bells and whistles.
     - [pydocstyle](www.pydocstyle.org/en/latest/)
     - [safety](https://pyup.io/docs/safety/installation-and-usage/)
     - [black](https://github.com/ambv/black)
+    - [blacken-docs](https://github.com/asottile/blacken-docs)
     - [mypy](http://mypy-lang.org/)
     - [interrogate](https://interrogate.readthedocs.io/en/latest/)
+    - [sphinx linkcheck](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.linkcheck.CheckExternalLinksBuilder)
+    - [build](https://pypi.org/project/build/) a PEP517 package builder
+- Some extra goodies for your development environment like...
+    - A preconfigured [editorconfig](https://editorconfig.org/) file.
+    - A preconfigured [bump2version](https://pypi.org/project/bump2version/) configuration file.
 
 
 # Quickstart
@@ -238,5 +250,6 @@ Inspiration (and some code) taken from the following:
 * [Hynek's blog post "Python in GitHub Actions](https://hynek.me/articles/python-github-actions/)
 * [Kyle Knapp's talk @ PyGotham 2018 "Automating Code Quality: Next Level](https://www.youtube.com/watch?v=iKAaNaVpJFM)
 * [Thea Flowers' talk @ PyCon 2019 "Break the Cycle: Three excellent Python tools to automate repetitive tasks"](https://www.youtube.com/watch?v=-BHverY7IwU)
+* [Daniele Procida's Diátaxis Documentation Framework](https://diataxis.fr/)
 * Everyone writing blog posts/github issues/mailing list responses/twitter rants/etc about Python packaging, best practices, and development workflows
 * All the wonderful folks writing the tools and services involved in this template and their documentation!

--- a/{{ cookiecutter.project_name }}/.editorconfig
+++ b/{{ cookiecutter.project_name }}/.editorconfig
@@ -16,6 +16,11 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
+# 3 space indentation
+[*.rst]
+indent_style = space
+indent_size = 3
+
 # 2 space indentation
 [*.{json,yml,yaml}]
 indent_style = space

--- a/{{ cookiecutter.project_name }}/.github/PULL_REQUEST_TEMPLATE.md
+++ b/{{ cookiecutter.project_name }}/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,4 +23,9 @@ in a comment on this pull request!
 This checklist is meant to make the process of contributing easier, not harder!
 
 - [ ] Added tests for changed code
+- [ ] Tests pass locally when invoked via `inv run.tests`
 - [ ] Updated documentation for changed code
+    - [ ] Documentation placed in the correct section according to
+    the [Diátaxis Framework](https://diataxis.fr/)
+    - [ ] New modules have a corresponding `.. automodule` entry in
+    `docs/reference`

--- a/{{ cookiecutter.project_name }}/.gitignore
+++ b/{{ cookiecutter.project_name }}/.gitignore
@@ -1,5 +1,27 @@
-# Byte-compiled / optimized / DLL files
+
+# Created by https://www.toptal.com/developers/gitignore/api/vim,emacs,flask,django,python,pycharm,sublimetext,visualstudio,visualstudiocode,jupyternotebooks,git,direnv,dotenv
+# Edit at https://www.toptal.com/developers/gitignore?templates=vim,emacs,flask,django,python,pycharm,sublimetext,visualstudio,visualstudiocode,jupyternotebooks,git,direnv,dotenv
+
+### direnv ###
+.direnv
+.envrc
+
+### Django ###
+*.log
+*.pot
+*.pyc
 __pycache__/
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+media
+
+# If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
+# in your Git repository. Update and uncomment the following line accordingly.
+# <django-project-name>/staticfiles/
+
+### Django.Python Stack ###
+# Byte-compiled / optimized / DLL files
 *.py[cod]
 *$py.class
 
@@ -8,21 +30,22 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
 parts/
 sdist/
 var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -37,21 +60,22 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
+*.py,cover
 .hypothesis/
+.pytest_cache/
+pytestdebug.log
 
 # Translations
 *.mo
-*.pot
 
 # Django stuff:
-*.log
-local_settings.py
 
 # Flask stuff:
 instance/
@@ -62,29 +86,834 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-docs_out
+doc/_build/
 
 # PyBuilder
 target/
 
-# IPython Notebook
+# Jupyter Notebook
 .ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
 
 # pyenv
 .python-version
 
-# celery beat schedule file
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
 celerybeat-schedule
+celerybeat.pid
 
-# dotenv
-.env
+# SageMath parsed files
+*.sage.py
 
-# virtualenv
+# Environments
+# .env
+.env/
+.venv/
+env/
 venv/
 ENV/
+env.bak/
+venv.bak/
+pythonenv*
 
 # Spyder project settings
 .spyderproject
+.spyproject
 
 # Rope project settings
 .ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# operating system-related files
+# file properties cache/storage on macOS
+*.DS_Store
+# thumbnail cache on Windows
+Thumbs.db
+
+# profiling data
+.prof
+
+
+### dotenv ###
+.env
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+ltximg/**
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+
+### Flask ###
+instance/*
+!instance/.gitignore
+
+### Flask.Python Stack ###
+# Byte-compiled / optimized / DLL files
+
+# C extensions
+
+# Distribution / packaging
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+
+# Installer logs
+
+# Unit test / coverage reports
+
+# Translations
+
+# Django stuff:
+
+# Flask stuff:
+
+# Scrapy stuff:
+
+# Sphinx documentation
+
+# PyBuilder
+
+# Jupyter Notebook
+
+# IPython
+
+# pyenv
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+
+# poetry
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+
+# Celery stuff
+
+# SageMath parsed files
+
+# Environments
+# .env
+
+# Spyder project settings
+
+# Rope project settings
+
+# mkdocs documentation
+
+# mypy
+
+# Pyre type checker
+
+# pytype static type analyzer
+
+# operating system-related files
+# file properties cache/storage on macOS
+# thumbnail cache on Windows
+
+# profiling data
+
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### JupyterNotebooks ###
+# gitignore template for Jupyter Notebooks
+# website: http://jupyter.org/
+
+*/.ipynb_checkpoints/*
+
+# IPython
+
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+
+# C extensions
+
+# Distribution / packaging
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+
+# Installer logs
+
+# Unit test / coverage reports
+
+# Translations
+
+# Django stuff:
+
+# Flask stuff:
+
+# Scrapy stuff:
+
+# Sphinx documentation
+
+# PyBuilder
+
+# Jupyter Notebook
+
+# IPython
+
+# pyenv
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+
+# poetry
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+
+# Celery stuff
+
+# SageMath parsed files
+
+# Environments
+# .env
+
+# Spyder project settings
+
+# Rope project settings
+
+# mkdocs documentation
+
+# mypy
+
+# Pyre type checker
+
+# pytype static type analyzer
+
+# operating system-related files
+# file properties cache/storage on macOS
+# thumbnail cache on Windows
+
+# profiling data
+
+
+### SublimeText ###
+# Cache files for Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# Workspace files are user-specific
+*.sublime-workspace
+
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
+# *.sublime-project
+
+# SFTP configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+### VisualStudio ###
+## Ignore Visual Studio temporary files, build results, and
+## files generated by popular Visual Studio add-ons.
+##
+## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
+
+# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
+# Mono auto generated files
+mono_crash.*
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
+# Visual Studio 2017 auto generated files
+Generated\ Files/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUnit
+*.VisualState.xml
+TestResult.xml
+nunit-*.xml
+
+# Build Results of an ATL Project
+[Dd]ebugPS/
+[Rr]eleasePS/
+dlldata.c
+
+# Benchmark Results
+BenchmarkDotNet.Artifacts/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
+
+# StyleCop
+StyleCopReport.xml
+
+# Files built by Visual Studio
+*_i.c
+*_p.c
+*_h.h
+*.ilk
+*.meta
+*.obj
+*.iobj
+*.pch
+*.pdb
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*_wpftmp.csproj
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# Chutzpah Test files
+_Chutzpah*
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+*.sap
+
+# Visual Studio Trace Files
+*.e2e
+
+# TFS 2012 Local Workspace
+$tf/
+
+# Guidance Automation Toolkit
+*.gpState
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# TeamCity is a build add-in
+_TeamCity*
+
+# DotCover is a Code Coverage Tool
+*.dotCover
+
+# AxoCover is a Code Coverage Tool
+.axoCover/*
+!.axoCover/settings.json
+
+# Coverlet is a free, cross platform Code Coverage Tool
+coverage*.[ji][sn][of][no]
+coverage*.xml
+
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+nCrunchTemp_*
+
+# MightyMoose
+*.mm.*
+AutoTest.Net/
+
+# Web workbench (sass)
+.sass-cache/
+
+# Installshield output folder
+[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/*.HxT
+DocProject/Help/*.HxC
+DocProject/Help/*.hhc
+DocProject/Help/*.hhk
+DocProject/Help/*.hhp
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+PublishScripts/
+
+# NuGet Packages
+*.nupkg
+# NuGet Symbol Packages
+*.snupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+*.appx
+*.appxbundle
+*.appxupload
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!?*.[Cc]ache/
+
+# Others
+ClientBin/
+~$*
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Including strong name files can present a security risk
+# (https://github.com/github/gitignore/pull/2483#issue-259490424)
+#*.snk
+
+# Since there are multiple workflows, uncomment next line to ignore bower_components
+# (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
+#bower_components/
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# SQL Server files
+*.mdf
+*.ldf
+*.ndf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings
+*.rptproj.rsuser
+*- [Bb]ackup.rdl
+*- [Bb]ackup ([0-9]).rdl
+*- [Bb]ackup ([0-9][0-9]).rdl
+
+# Microsoft Fakes
+FakesAssemblies/
+
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+
+# Node.js Tools for Visual Studio
+.ntvs_analysis.dat
+node_modules/
+
+# Visual Studio 6 build log
+*.plg
+
+# Visual Studio 6 workspace options file
+*.opt
+
+# Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
+*.vbw
+
+# Visual Studio LightSwitch build output
+**/*.HTMLClient/GeneratedArtifacts
+**/*.DesktopClient/GeneratedArtifacts
+**/*.DesktopClient/ModelManifest.xml
+**/*.Server/GeneratedArtifacts
+**/*.Server/ModelManifest.xml
+_Pvt_Extensions
+
+# Paket dependency manager
+.paket/paket.exe
+paket-files/
+
+# FAKE - F# Make
+.fake/
+
+# CodeRush personal settings
+.cr/personal
+
+# Python Tools for Visual Studio (PTVS)
+
+# Cake - Uncomment if you are using it
+# tools/**
+# !tools/packages.config
+
+# Tabs Studio
+*.tss
+
+# Telerik's JustMock configuration file
+*.jmconfig
+
+# BizTalk build output
+*.btp.cs
+*.btm.cs
+*.odx.cs
+*.xsd.cs
+
+# OpenCover UI analysis results
+OpenCover/
+
+# Azure Stream Analytics local run output
+ASALocalRun/
+
+# MSBuild Binary and Structured Log
+*.binlog
+
+# NVidia Nsight GPU debugger configuration file
+*.nvuser
+
+# MFractors (Xamarin productivity tool) working folder
+.mfractor/
+
+# Local History for Visual Studio
+.localhistory/
+
+# BeatPulse healthcheck temp database
+healthchecksdb
+
+# Backup folder for Package Reference Convert tool in Visual Studio 2017
+MigrationBackup/
+
+# Ionide (cross platform F# VS Code tools) working folder
+.ionide/
+
+# Fody - auto-generated XML schema
+FodyWeavers.xsd
+
+### VisualStudio Patch ###
+# Additional files built by Visual Studio
+*.tlog
+
+# End of https://www.toptal.com/developers/gitignore/api/vim,emacs,flask,django,python,pycharm,sublimetext,visualstudio,visualstudiocode,jupyternotebooks,git,direnv,dotenv

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -71,5 +71,5 @@ $ inv pindeps
 
 {%- if include_link_back %}
 
-_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.41.1_
+_Created using [bnbalsamo/cookiecutter-pypackage](https://github.com/bnbalsamo/cookiecutter-pypackage) v0.42.0_
 {% endif -%}

--- a/{{ cookiecutter.project_name }}/docs/conf.py
+++ b/{{ cookiecutter.project_name }}/docs/conf.py
@@ -33,8 +33,12 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.todo',
+    'sphinx_autodoc_typehints',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -78,8 +82,12 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = False
+todo_include_todos = bool(os.environ.get("SPHINX_DISPLAY_TODOS"))
 
+# Set typing.TYPE_CHECKING to True to enable “expensive” typing imports
+set_type_checking_flag = True
+# Add stub documentation for undocumented parameters to be able to add type info.
+always_document_param_types = True
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/{{ cookiecutter.project_name }}/docs/explanations.rst
+++ b/{{ cookiecutter.project_name }}/docs/explanations.rst
@@ -1,0 +1,11 @@
+Explanations
+============
+
+How This Documentation is Organized
+-----------------------------------
+
+This documentation is organized according to the
+`Diátaxis Framework <https://diataxis.fr/>`_.
+
+For more information see
+`How to Use Diátaxis <https://diataxis.fr/how-to-use-diataxis/#how-to-use-diataxis>`_.

--- a/{{ cookiecutter.project_name }}/docs/how-tos.rst
+++ b/{{ cookiecutter.project_name }}/docs/how-tos.rst
@@ -1,0 +1,4 @@
+How-Tos
+=======
+
+Nothing here yet!

--- a/{{ cookiecutter.project_name }}/docs/index.rst
+++ b/{{ cookiecutter.project_name }}/docs/index.rst
@@ -6,12 +6,18 @@
 Welcome to {{cookiecutter.project_name}}'s documentation!
 =========================================================
 
+{{ cookiecutter.short_description }}
+
+.. todolist::
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-   autodoc
-
+   tutorials
+   how-tos
+   reference
+   explanations
 
 
 Indices and tables

--- a/{{ cookiecutter.project_name }}/docs/reference.rst
+++ b/{{ cookiecutter.project_name }}/docs/reference.rst
@@ -1,5 +1,8 @@
-Auto Docs
+Reference
 =========
+
+API Reference
+-------------
 
 .. automodule:: {{ cookiecutter.module_name }}
    :members:

--- a/{{ cookiecutter.project_name }}/docs/tutorials.rst
+++ b/{{ cookiecutter.project_name }}/docs/tutorials.rst
@@ -1,0 +1,8 @@
+Tutorials
+=========
+
+.. todo::
+
+   Add a basic tutorial
+
+Nothing here yet!

--- a/{{ cookiecutter.project_name }}/setup.py
+++ b/{{ cookiecutter.project_name }}/setup.py
@@ -43,6 +43,7 @@ EXTRAS_REQUIRE = {
     "docs": [
         "sphinx",
         "sphinx_rtd_theme",
+        "sphinx-autodoc-typehints",
     ]
 }
 ENTRY_POINTS = {

--- a/{{ cookiecutter.project_name }}/tasks.py
+++ b/{{ cookiecutter.project_name }}/tasks.py
@@ -335,12 +335,36 @@ def release(c, prod=False, clean=True, build=True, skip_tests=False, autoformat=
     echo("Upload complete")
 
 
-@task(name="docs")
-def serve_docs(c):
+@task(name="docs", iterable=['additional_dir'])
+def serve_docs(c, todos=False, additional_dir=None, open_browser=False):
     """
     Serve the docs on localhost:8000. Reload on changes.
     """
-    c.run("sphinx-autobuild --watch src docs docs/_build/html")
+    argv = ["sphinx-autobuild"]
+
+    if open_browser:
+        argv.append("--open-browser")
+
+    # Default additional dirs we want to watch for changes
+    default_additional_dirs = ["src"]
+    for default in default_additional_dirs:
+        additional_dir.append(default)
+
+    # Append append defaults + user specified dirs to argv
+    additional_dir.append("src")
+    for dir_ in additional_dir:
+        argv.append("--watch")
+        argv.append(dir_)
+
+    # sphinx-autobuild positional args
+    argv.append("docs")
+    argv.append("docs/_build/html")
+
+    # See relevant logic in docs/conf.py
+    if todos:
+        os.environ["SPHINX_DISPLAY_TODOS"] = "true"
+
+    c.run(" ".join(argv))
 
 
 # Make implicit root explicit


### PR DESCRIPTION
Updates the docs of the generated projects.

- The docs now use the [Diátaxis Documentation Framework](https://diataxis.fr/).
- Moved the autodocs into the reference section of the new docs layout
- Add `sphinx.ext.todo` and `sphinx_autodoc_typehints` to the sphinx
  extensions, with relevant configuration.
- Significantly updates the `inv serve.docs` command
  - It now optionally renders the `todos` in the dev docs
  - It now has a (repeatable) flag for watching additional directories
  - It now has a flag for automatically opening the browser

Adds an editorconfig configuration for `rst` files to set indents to 3
spaces.

Adds a few more checkboxes to the PR template, specifically one for
tests passing locally and two for updating the docs.

Updates the project's README to include some more relevant information
and links for recent template changes.

Updates (and significantly expands) the `.gitignore` in the generated
project, utilizing gitignore.io.