### PR TITLE
Convert default branch name to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,3 +40,16 @@ jobs:
           poetry run inv build.zipapp
           poetry run inv clean
           poetry run inv check.todos
+      - name: "Build test example"
+        run: |
+          echo -e "bnb-cookiecutter-example-test\n\n\n\n\n\n\n\nbnbalsamo\n\n\n\n\n" | cookiecutter .
+      - name: Push to test example repository
+        uses: cpina/github-action-push-to-another-repository@master
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: "bnb-cookiecutter-example-test"
+          destination-github-username: "bnbalsamo"
+          destination-repository-name: "bnb-cookiecutter-example-test"
+          target-branch: "main"
+          user-email: "Brian@BrianBalsamo.com"

--- a/.github/workflows/make_example_repo.yml
+++ b/.github/workflows/make_example_repo.yml
@@ -30,7 +30,8 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source-directory: 'bnb-cookiecutter-example'
-          destination-github-username: 'bnbalsamo'
-          destination-repository-name: 'bnb-cookiecutter-example'
-          user-email: 'Brian@BrianBalsamo.com'
+          source-directory: "bnb-cookiecutter-example"
+          destination-github-username: "bnbalsamo"
+          destination-repository-name: "bnb-cookiecutter-example"
+          target-branch: "main"
+          user-email: "Brian@BrianBalsamo.com"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,7 +8,7 @@
     "email": "you@provider.com",
     "github_repo_name": "{{ cookiecutter.project_name }}",
     "github_username": "githubber",
-    "github_default_branch_name": "master",
+    "github_default_branch_name": "main",
     "license": [
         "GNU GPLv3",
         "GNU AGPLv3",

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -2,7 +2,7 @@
 # {{cookiecutter.project_name}} [![v{{ cookiecutter.version }}](https://img.shields.io/badge/version-{{ cookiecutter.version }}-blue.svg)](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}/releases)
 
 [![CI](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}/workflows/CI/badge.svg?branch={{ cookiecutter.github_default_branch_name }})](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}/actions)
-[![Coverage](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}/branch/master/graph/badge.svg)](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}/)
+[![Coverage](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}/branch/{{ cookiecutter.github_default_branch_name }}/graph/badge.svg)](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}/)
 [![Documentation Status](https://readthedocs.org/projects/{{ cookiecutter.github_repo_name }}/badge/?version=latest)](http://{{ cookiecutter.github_repo_name }}.readthedocs.io/en/latest/?badge=latest)
 [![Updates](https://pyup.io/repos/github/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}/shield.svg)](https://pyup.io/repos/github/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -18,7 +18,7 @@ This project is currently only installable via development tooling.
 - Install [poetry](https://python-poetry.org/)
 - ```$ git clone https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}.git```
 - ```$ cd {{ cookiecutter.github_repo_name }}```
-- ```$ poetry install . --no-dev```
+- ```$ poetry install --no-dev```
 
 # Development
 
@@ -26,11 +26,11 @@ To install + configure a development environment...
 
 - Install [poetry](https://python-poetry.org/)
 - Clone the repository
-    - `git@github.com:{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}.git`
+    - `git clone git@github.com:{{ cookiecutter.github_username }}/{{ cookiecutter.github_repo_name }}.git`
 - `cd` into the project directory
     - `cd {{ cookiecutter.github_repo_name }}`
 - Install the project and development dependencies with poetry
-    - `poetry install .`
+    - `poetry install`
 - Activate the project's virtual environment in your current shell
     - `poetry shell`
 - Install the pre-commit hooks


### PR DESCRIPTION
Converts the default branch name in the template to "main"

Additionally, changes the name of the branch in the example.

Closes #45