### PR TITLE
Nox notify coverage

### DIFF
--- a/{{ cookiecutter.project_name }}/.pylintrc
+++ b/{{ cookiecutter.project_name }}/.pylintrc
@@ -140,7 +140,8 @@ disable=print-statement,
         exception-escape,
         comprehension-escape,
         fixme,
-        bad-continuation
+        bad-continuation,
+        unspecified-encoding
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -12,7 +12,7 @@ sphinx = {version = "*", optional = true}
 sphinx-autodoc-typehints = {version = "*", optional = true}
 sphinx-rtd-theme = {version = "*", optional = true}
 pytest = {version = "*", optional = true}
-pytest-cov = {version = "*", optional = true}
+coverage = {version = "*", optional = true, extras = ["toml"]}
 typing-extensions = {version = "*", optional = true}
 
 [tool.poetry.extras]
@@ -24,7 +24,7 @@ docs = [
 ]
 tests = [
     "pytest",
-    "pytest-cov",
+    "coverage",
 ]
 
 [tool.poetry.dev-dependencies]

--- a/{{ cookiecutter.project_name }}/tasks.py
+++ b/{{ cookiecutter.project_name }}/tasks.py
@@ -170,12 +170,12 @@ def clean_mypy():
 
 def clean_coverage():
     """Remove the .coverage cache."""
-    coverage_cache_file = Path("./.coverage").resolve()
-    if coverage_cache_file.exists() and coverage_cache_file.is_file():
-        coverage_cache_file.unlink()
-        echo(f"{str(coverage_cache_file)} removed.")
-    else:
-        echo(f"No file found at {str(coverage_cache_file)}")
+    # Nox takes care of .coverage on its own
+    # We just don't want extras in our coverage combine call.
+    for coverage_cache_file in Path().glob(".coverage.*"):
+        if coverage_cache_file.exists() and coverage_cache_file.is_file():
+            coverage_cache_file.unlink()
+            echo(f"{str(coverage_cache_file)} removed.")
 
 
 def clean_coverage_report():


### PR DESCRIPTION
Switch to using nox's `session.notify` functionality to run the coverage
environment.

This will cause coverage to be reported against all runs combined (and
so only fail if combined coverage is below the target).

Change `tasks.py` to handle the generation of different coverage reports
created by `coverage`'s `-p` option. Nox now handles the `.coverage`
file itself.

Additionally, excludes the requirement to specify file encodings in
calls to open from the `.pylintrc`